### PR TITLE
feat: Added responsive Footer component

### DIFF
--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -86,7 +86,7 @@ export default function Footer() {
                     </div>
                     <div className="font-trapix text-lg flex flex-col">
                         Email
-                        <div className="font-formular-mono text-xs mt-2">samahan<span className="font-fontspring text-xs">@</span>addu.edu.ph</div>
+                        <div className="font-formular-mono text-xs mt-2">samahan<span className="font-trapix text-xs">@</span>addu.edu.ph</div>
                     </div>
                     <div className="font-trapix text-lg flex flex-col">
                         Socials
@@ -105,7 +105,7 @@ export default function Footer() {
                 {/* Assets By */}
                 <div className="left assets-by font-formular-mono text-sm flex flex-col text-center lg:text-left">
                     <div className="flex-row">Assets by <span className="font-trapix">SAMAHAN Creative Team</span></div>
-                    <div className="flex-row">Developed by <span className="font-trapix">SAMAHAN Systems Development</span></div>
+                    <div className="flex-row">Developed by <Link href="/" className="hover:underline"><span className="font-trapix">SAMAHAN Systems Development</span></Link></div>
                 </div>
                 {/* Copyright */}
                 <div className="right copyright font-formular-mono text-sm">


### PR DESCRIPTION
- Added  Footer.tsx under src\components\ui
- Responsive across all viewports

**ADDITIONAL NOTES**

- Placeholder images placed in lieu of logos for now
- Used Link tags for items under Quick links, Offices, and Policies, but no proper routing yet
- Added routing for Facebook, Instagram and X icons; will direct to official SAMAHAN social media pages
- Footer component not added to layout.tsx yet, only added as a  UI component for now

**DESKTOP VIEW (for large viewports)**

<img width="1366" height="637" alt="image" src="https://github.com/user-attachments/assets/7ed54327-61cc-4854-9ae6-7b7340296803" />


**MOBILE VIEW (for medium, small, extra-small viewports)**

![Screenshot_11-10-2025_175432_localhost](https://github.com/user-attachments/assets/516ccf53-0c0d-47e6-a8a4-bd0f72c62553)

