### PR TITLE
Feat: Office Card component

### DIFF
--- a/src/components/ui/OfficeCard.tsx
+++ b/src/components/ui/OfficeCard.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+import Image from "next/image";
+
+interface OfficeCardProps {
+  imageUrl?: string;
+  officeName: string;
+  href?: string;
+}
+
+export default function OfficeCard({
+  imageUrl = "/images/placeholder.png",
+  officeName,
+  href = "/",
+}: OfficeCardProps) {
+  return (
+    <Link href={href} className="block group w-60 md:w-64 lg:w-68">
+      <div className="relative overflow-hidden rounded-lg shadow-md hover:shadow-lg transition-shadow duration-300 border-2 border-mainblue">
+        <div className="relative h-20 md:h-24 lg:h-28">
+          <Image
+            src={imageUrl}
+            alt={officeName}
+            fill
+            className="object-cover"
+          />
+          <div className="absolute inset-0 bg-mainblue/50 bg-opacity-60"></div>
+        </div>
+
+        <div className="bg-mainblue px-3 py-2">
+          <h3 className="text-white pt-0.5 font-trapix text-md text-center">
+            {officeName}
+          </h3>
+        </div>
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
Resolves issue #10

## Features
- Reusable & responsive office card button
- Takes in imageUrl and OfficceName as arguments

## Images
- Mobile View:
- <img width="392" height="847" alt="mobileView" src="https://github.com/user-attachments/assets/35e4fe0a-21c6-4c59-90ca-33728cf13230" />

- Desktop View:
- <img width="1920" height="919" alt="desktopView" src="https://github.com/user-attachments/assets/56ae26f6-0d7e-4c62-9fd5-f128f5cb45f5" />

