### PR TITLE
feat(#009): added Project Card with placeholder image

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -22,16 +22,27 @@ export default function Home() {
         <div className="bg-blue2 h-4 w-4"></div>
       </div>
       <div className="mt-8 space-y-2">
-          <div className="uppercase font-extrabold">Font families and styles:</div>
+        <div className="uppercase font-extrabold">
+          Font families and styles:
+        </div>
         <div className="font-trapix text-lg">- Trapix 400 Regular</div>
         <div className="font-formular-mono text-lg">- Formular 950 Mono</div>
         <div className="font-formular-black text-lg">- Formular 900 Black</div>
-        <div className="font-formular-medium text-lg">- Formular 500 Medium</div>
+        <div className="font-formular-medium text-lg">
+          - Formular 500 Medium
+        </div>
         <div className="font-formular-bold text-lg">- Formular 700 Bold</div>
-        <div className="font-formular-regular text-lg">- Formular 400 Regular</div>
-        <div className="font-fontspring text-lg">- FONTSPRING DEMO - Breul Grotesk A 300 Regular</div>
+        <div className="font-formular-regular text-lg">
+          - Formular 400 Regular
+        </div>
+        <div className="font-fontspring text-lg">
+          - FONTSPRING DEMO - Breul Grotesk A 300 Regular
+        </div>
       </div>
-      <div className="mt-8 font-extrabold uppercase">Test your components below</div>
+      <div className="mt-8 font-extrabold uppercase">
+        Test your components below
+      </div>
+
     </div>
   );
 }

--- a/src/components/ui/ProjectCard.tsx
+++ b/src/components/ui/ProjectCard.tsx
@@ -1,0 +1,45 @@
+import Image from "next/image";
+import Link from "next/link";
+import { trapix, formularRegular } from "@/app/font";
+
+type ProjectCardProps = {
+  imageUrl: string;
+  title: string;
+  description: string;
+  url: string;
+};
+
+const ProjectCard = ({
+  imageUrl,
+  title,
+  description,
+  url,
+}: ProjectCardProps) => {
+  return (
+    <div className="w-full max-w-xs sm:max-w-xs h-auto m-4 rounded-2xl overflow-hidden bg-gradient-to-b from-mainblue from-60% to-blue2 flex flex-col">
+      <div className="relative w-full sm:h-60 h-48">
+        <Image src={imageUrl} alt={title} layout="fill" objectFit="cover" />
+      </div>
+
+      <div className="pt-8 px-4 pb-6 sm:px-4 flex flex-col gap-5 sm:gap-4 flex-grow">
+        <h3 className={`${trapix.className} text-3xl text-white uppercase`}>
+          {title}
+        </h3>
+        <p
+          className={`${formularRegular.className} text-sm text-white  max-h-20 sm:max-h-none overflow-hidden`}
+        >
+          {description}
+        </p>
+
+        <Link
+          href={url}
+          className={`${formularRegular.className} font-normal mt-2 inline-block self-center rounded-full border border-white px-2 sm:px-6 py-2 text-xs sm:text-sm text-white transition-colors hover:bg-white hover:text-mainblue`}
+        >
+          View More ▸
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default ProjectCard;


### PR DESCRIPTION
Created Project Card in 'src\components\ui\ProjectCard.tsx'

### Features
- blue gradient background from mainblue to blue2
- used imageUrl, title, description, url as the arguments
- <img width="600" height="916" alt="arguments" src="https://github.com/user-attachments/assets/813ce1dd-8942-4ea9-9497-76d2a32bd043" />
- added overflow-hidden and max-h-20 to prevent long descriptions from breaking the card layout on mobile

### Images

- Desktop
- <img width="600" height="936" alt="projectCard_desktop" src="https://github.com/user-attachments/assets/cdcd3067-5f54-45c5-8674-b1029325a33a" />

- Mobile
- <img width="250" alt="projectCard_mobile" src="https://github.com/user-attachments/assets/d5c8947b-cff6-4930-a117-848b3266dc7c">