### PR TITLE
fix: fixed wrong label for Advocasix card from SOGISC to SOGIESC

### DIFF
--- a/src/data/advocasix-card-data.ts
+++ b/src/data/advocasix-card-data.ts
@@ -34,7 +34,7 @@ export const advocasixData: AdvocasixCardData[] = [
     content: "Guided by its principles as a Jesuit, Filipino, and Mindanaoan autonomous student government, the Samahan ng mga Mag-aaral ng Pamantasan ng Ateneo de Davao set the goal of championing the identified AdvocaSIX for the incoming 6 years that started on 2022 and aims to cultivate until 2028. With that, SAMAHAN shall hereby champion the following advocacies for the term of 2024-2025:"
   },
   {
-    cardTitle: "sogiSC",
+    cardTitle: "sogieSC",
     image: { imgSource: "/images/placeholder.png", imgAlt: "placeholder" },
     content: "Guided by its principles as a Jesuit, Filipino, and Mindanaoan autonomous student government, the Samahan ng mga Mag-aaral ng Pamantasan ng Ateneo de Davao set the goal of championing the identified AdvocaSIX for the incoming 6 years that started on 2022 and aims to cultivate until 2028. With that, SAMAHAN shall hereby champion the following advocacies for the term of 2024-2025:"
   },


### PR DESCRIPTION
Resolves issue #75

under src\data\advocasix-card-data.ts
Fixed label typo from SogiSC to SogieSC
```
{
    cardTitle: "sogieSC",
    image: { imgSource: "/images/placeholder.png", imgAlt: "placeholder" },
    content: "Guided by its principles as a Jesuit, Filipino, and Mindanaoan autonomous student government, the Samahan ng mga Mag-aaral ng Pamantasan ng Ateneo de Davao set the goal of championing the identified AdvocaSIX for the incoming 6 years that started on 2022 and aims to cultivate until 2028. With that, SAMAHAN shall hereby champion the following advocacies for the term of 2024-2025:"
  },
```

### Images
<img width="354" alt="sogiesc-card" src="https://github.com/user-attachments/assets/fb643926-9f9d-48d7-b117-f362fcfa35dc" />
