### PR TITLE
fix: fix advocasix modal blur issue

### DIFF
--- a/src/components/ui/advocasix-modal.tsx
+++ b/src/components/ui/advocasix-modal.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { X } from "lucide-react";
-import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogOverlay } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 
 interface AdvocasixModalProps {
@@ -24,6 +24,7 @@ export default function AdvocasixModal({
 }: AdvocasixModalProps) {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogOverlay className="fixed inset-0 bg-black/40 backdrop-blur-sm" />
       <DialogContent
         onInteractOutside={(e) => e.preventDefault()}
         className={cn(


### PR DESCRIPTION
Resolves issue #77 

under src\components\ui\advocasix-modal.tsx
- Imported DialogOverlay from "@/components/ui/dialog"
- Added <DialogOverlay /> inside AdvocasixModal

### Desktop view
<img width="1200" alt="desktop-blur" src="https://github.com/user-attachments/assets/c5cf0c77-fa8d-474f-ab2c-ae3620fa355a" />

### Mobile View
<img width="423" alt="mobile-blur" src="https://github.com/user-attachments/assets/dfe5c599-44db-4d77-ba04-6b682ea4730c" />
