### PR TITLE
Fix/79  navbar mobile arrow open state

### DIFF
--- a/src/components/ui/navigation-bar.tsx
+++ b/src/components/ui/navigation-bar.tsx
@@ -62,7 +62,7 @@ export default function Navbar() {
               <span>Offices</span>
               <FiChevronRight className="transition-transform duration-300 group-open/office:rotate-90" />
             </summary>
-            <div className="pl-4 pb-2 ">
+            <div className="pl-4 pb-2">
               {offices.map((o) => (
                 <Link
                   key={o.href}


### PR DESCRIPTION
Resolves issue #79 

- Added import <FiChevronRight />
- replaced <FiChevronDown /> with <FiChevronRight /> in mobile collapsibles
- Add named group scopes: group/office and group/infop for rotation utilities

### Images
<img width="300" alt="image" src="https://github.com/user-attachments/assets/f3ab773b-214c-4769-8f75-2c59969eebed" />
<img width="300" alt="image" src="https://github.com/user-attachments/assets/a0a478e0-b3f7-4289-9cc9-baee553fb015" />
