### PR TITLE
Feat: Created a Profile Group Section component

### DIFF
--- a/src/components/sections/profile-group.tsx
+++ b/src/components/sections/profile-group.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+interface ProfileGroupProps {
+  groupTitle: string;
+  description: string;
+  children: React.ReactNode;
+}
+
+export default function ProfileGroup({
+  groupTitle,
+  description,
+  children,
+}: ProfileGroupProps) {
+  return (
+    <section className="flex w-full flex-col items-center px-8 py-12 md:py-16">
+      <div className="flex w-full max-w-7xl flex-col">
+        <h2 className="font-formular-black text-center text-2xl uppercase text-mainblue md:text-3xl lg:text-4xl">
+          {groupTitle}
+        </h2>
+
+        <p className="font-formular-regular mt-4 text-center text-sm leading-relaxed text-mainblue md:text-base">
+          {description}
+        </p>
+
+        <div className="mt-10 md:mt-12">{children}</div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Resolves issue #49 

## Features
- Created reusable `ProfileGroup` component that accepts `groupTitle`, `description`, and `children` props

## Desktop View
<img width="645" height="594" alt="Screenshot 2025-11-21 at 8 27 04 PM" src="https://github.com/user-attachments/assets/10caaa3b-7913-46b0-8120-4f5055b3f3c2" />


## Mobile View
<img width="316" height="689" alt="Screenshot 2025-11-21 at 8 26 26 PM" src="https://github.com/user-attachments/assets/a5390a33-9bcd-4a71-9b0a-05d32f24db6d" />


## Testing
```tsx
/* Add to src/app/(public)/page.tsx
<div className="py-8 md:py-12">
  <ProfileGroup
    groupTitle="OFFICE OF THE SAMAHAN VICE PRESIDENT"
    description="Lorem ipsum dolor sit amet, cons ectetur adipiscing elit, sed diam th euismod tincidunt ut laoreet dolore magna aliquam et voluptuat."
  >
    <ProfileCardComponentHere/>
  </ProfileGroup>

  <ProfileGroup
    groupTitle="DEPARTMENT OF ACADEMIC AFFAIRS"
    description="The SAMAHAN Department of Academic Affairs (DAA) serves as the academic arm of the SAMAHAN, under the Office of the SAMAHAN Vice President. At its core, the department is committed to promoting the academic welfare of the student body. It strives to provide support through various initiatives that respond to students' academic needs. The DAA also plays a role in examining and reflecting on academic policies, contributing student-centered insights that help improve the learning environment."
  >
    <ProfileCardComponentHere/>
  </ProfileGroup>
</div>

*/
