### PR TITLE
Create Request Documents Tab Section

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -4,11 +4,13 @@ export const metadata: Metadata = {
   title: "SAMAHAN Website 2025-2026",
   description: "Frontend for Samahan Website",
 };
-
+import DocumentRequestTabSection from "@/components/sections/document-request-tab-section";
 export default function Home() {
   return (
     <>
-      <HomePageClient />
+      {/* <HomePageClient />
+      HELLO */}
+      <DocumentRequestTabSection></DocumentRequestTabSection>
     </>
   );
 }

--- a/src/components/sections/document-request-tab-section.tsx
+++ b/src/components/sections/document-request-tab-section.tsx
@@ -1,0 +1,149 @@
+"use client";
+import TabHeader from "../ui/tab-header";
+export default function DocumentRequestTabSection() {
+  return (
+    <div className="px-4 sm:px-8 md:px-16 lg:px-40 py-4 md:py-8">
+      <TabHeader name="REQUEST FOR OFFICIAL DOCUMENTS"></TabHeader>
+      <div className="px-10 sm:px-8 md:px-16 lg:px-32 py-6 md:py-12 lg:py-16">
+        <div className="pr-40 sm:pr-40 md:pr-14 lg:pr-20">
+          {" "}
+          <p className="font-formular text-mainblue font-medium text-base sm:text-lg md:text-xl lg:text-2xl mb-3 sm:mb-4">
+            REGISTRAR'S OFFICE:
+          </p>
+        </div>
+        <div className="font-formular text-mainblue text-sm sm:text-sm md:text-base space-y-4 sm:space-y-3 md:space-y-4 pl-0 sm:pl-4 md:pl-8">
+          <p className="leading-relaxed">
+            The form caters to both current students and alumni. The students
+            and alumni should fill this out in order to request documents and
+            for drive-through payment and claim of the requested document(s).
+          </p>
+          <p className="leading-relaxed">
+            Access the{" "}
+            <a href="URL_HERE" className="text-mainblue underline font-medium">
+              link
+            </a>{" "}
+            if you intend to request for any of the following documents:
+            Transcript of Records (TOR) for Board Exam (Please upload 2x2
+            picture) -- Required for licensure examinations.
+          </p>
+        </div>
+
+        <div className="mt-4 px-4 sm:px-8 md:px-12 lg:px-20">
+          <ol className="text-mainblue text-sm sm:text-sm md:text-base leading-tight space-y-1 sm:space-y-2 list-decimal marker:font-bold pl-5 sm:pl-6">
+            <li>
+              <strong>Diploma, (Certified True Copy)</strong> -- A certified
+              replica of your diploma.
+            </li>
+            <li>
+              <strong>Diploma, Original</strong> -- (Issued only once and
+              Subject to verification).
+            </li>
+            <li>
+              <strong>Diploma (Second Copy)</strong> -- May be denied release
+              for cause. Affidavits of explanation justifying the request must
+              be sent as part of your response to the confirmation email which
+              you will receive subsequently.
+            </li>
+            <li>
+              <strong>Reissued LLB to Juris Doctor Diploma</strong> -- A
+              replacement or re-issuance of LLB your diploma, per LLB circular.
+            </li>
+            <li>
+              <strong>Honorable Dismissal (Subject to verification)</strong> --
+              Only one copy allowed for release (issued only once). This is
+              requested as part of the credentials for students/graduates who
+              desire to transfer to other schools.
+            </li>
+            <li>
+              <strong>
+                Certification, Authentication, and Verification from (CAV) CHED
+                (Local)
+              </strong>
+            </li>
+            <li>
+              <strong>
+                Certification, Authentication, and Verification (CAV) from CHED
+                (Abroad) / DFA
+              </strong>
+            </li>
+            <li>
+              <strong>Certification: Bona Fide Student</strong> -- Certifies the
+              period of attendance of the requesting party as an incumbent
+              student of their specific program.
+            </li>
+            <li>
+              <strong>
+                Certification: Complete Academic Requirements (Graduate School)
+              </strong>
+            </li>
+            <li>
+              <strong>
+                Certification: Eligibility (C1) Authentication for J.D.
+              </strong>
+            </li>
+            <li>
+              <strong>Certification: Enrollment</strong> -- Specify school year
+              and semester in the details.
+            </li>
+            <li>
+              <strong>Certification: Grades</strong> -- Please indicate in the
+              details the school year, semester, and number of copies.
+            </li>
+            <li>
+              <strong>Certification: Graduation</strong> -- Certifies the
+              details relative to the grant of the degree by a graduate.
+            </li>
+            <li>
+              <strong>Certification: Medium of Instruction (MOI)</strong> --
+              Indicates that the medium of instruction by the University is
+              English, unless otherwise required by law.
+            </li>
+            <li>
+              <strong>Certification: Units Earned</strong>
+            </li>
+            <li>
+              <strong>Certification: QPI / GWPA</strong>
+            </li>
+            <li>
+              <strong>Course Description</strong> -- (Processing time: 2 weeks.
+              Please specify in the details if requesting specific courses
+              (subjects) or all)
+            </li>
+            <li>
+              <strong>Letter of no Objection</strong> -- Subject to
+              verification.
+            </li>
+            <li>
+              <strong>
+                Australian Health Practitioner Regulation Agency Documents
+              </strong>{" "}
+              -- 2 CTC Diploma, Original TOR abroad with 2 authentications, 2
+              Letter of Confirmation, Autonomous Certificate (cert. of fee),
+              Certificate of AHPRA, 1 long brown envelope.
+            </li>
+          </ol>
+        </div>
+        <button className="bg-mainblue text-white px-8 py-3 sm:px-6 sm:py-2.5 md:px-8 md:py-3 rounded-3xl mt-6 sm:mt-6 md:mt-8 text-xs sm:text-sm md:text-base font-medium uppercase tracking-wide">
+          REQUEST REGISTRAR'S CERTIFICATE
+        </button>
+        <h2 className="font-formular text-mainblue font-medium text-base sm:text-lg md:text-xl lg:text-2xl mt-8 sm:mt-10 md:mt-12">
+          OFFICE OF THE STUDENT AFFAIRS:
+        </h2>
+        <div className="font-formular text-mainblue px-2 sm:px-4 mt-2 sm:mt-3 md:mt-4">
+          <ol className="text-mainblue text-xs sm:text-sm md:text-base px-4 sm:px-6 md:px-8 mt-2 sm:mt-3 md:mt-4 list-decimal marker:font-bold space-y-1 sm:space-y-2">
+            <li>
+              <strong>Certificate of Good Moral Character</strong>
+            </li>
+          </ol>
+        </div>
+        <div className="px-6 sm:px-10 md:px-14 font-formular text-mainblue text-xs sm:text-sm md:text-base mt-2">
+          a. Access the link to request the said document. Please note that the
+          form is only intended for the utilization of the Undergraduate Unit.
+        </div>
+        <button className="bg-mainblue text-white px-8 py-3 sm:px-6 sm:py-2.5 md:px-8 md:py-3 rounded-3xl mt-6 sm:mt-6 md:mt-8 text-xs sm:text-sm md:text-base font-medium uppercase tracking-wide">
+          REQUEST CERTIFICATE
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/ui/navigation-bar.tsx
+++ b/src/components/ui/navigation-bar.tsx
@@ -26,7 +26,6 @@ const infoPortal = [
 export default function Navbar() {
   return (
     <div className="sticky top-0 z-50 py-4 px-4 sm:px-6 lg:px-8 xl:px-24 2xl:px-40 select-none">
-      {/* Mobile: details/summary toggle (no hooks) */}
       <details className="lg:hidden group relative">
         <summary className="list-none">
           <div className="bg-mainblue h-14 flex items-center justify-between px-4 sm:px-6 rounded-none">
@@ -44,7 +43,6 @@ export default function Navbar() {
           </div>
         </summary>
 
-        {/* Mobile menu panel overlay */}
         <div className="absolute left-0 right-0 top-14 mt-0 px-0 bg-mainblue text-white rounded-b-2xl shadow-md divide-y divide-white/10 z-40  overflow-y-auto">
           {headLinks.map((l) => (
             <Link
@@ -56,7 +54,6 @@ export default function Navbar() {
             </Link>
           ))}
 
-          {/* Offices collapsible */}
           <details className="px-2 py-1 group">
             <summary className="w-full flex items-center justify-between px-2 py-2 font-formular-mono cursor-pointer hover:bg-white/10 rounded-md">
               <span>Offices</span>
@@ -82,7 +79,6 @@ export default function Navbar() {
             FAQ
           </Link>
 
-          {/* Information portal collapsible */}
           <details className="px-2 py-1 group">
             <summary className="w-full flex items-center justify-between px-2 py-2 font-formular-mono cursor-pointer hover:bg-white/10 rounded-md">
               <span>Information Portal</span>
@@ -103,7 +99,6 @@ export default function Navbar() {
         </div>
       </details>
 
-      {/* Desktop nav (unchanged layout; mapped content) */}
       <div className="hidden lg:block">
         <div className="bg-mainblue h-14 flex items-center justify-between lg:px-6 xl:px-10 rounded-full">
           <Link href="/" className="relative h-6 w-20  xl:w-22">
@@ -124,7 +119,6 @@ export default function Navbar() {
               </Link>
             ))}
 
-            {/* Offices dropdown (hover) */}
             <div className="relative inline-block align-middle group">
               <button
                 type="button"
@@ -155,7 +149,6 @@ export default function Navbar() {
               FAQ
             </Link>
 
-            {/* Information portal dropdown (hover) */}
             <div className="relative inline-block align-middle group">
               <button
                 type="button"


### PR DESCRIPTION
Createed a request tab section with desktop and mobile breakpoints in
/src/components/sections/request-documents-tab-section.tsx

Desktop:
<img width="1855" height="781" alt="image" src="https://github.com/user-attachments/assets/349da12e-e55c-408d-ab2d-c9804de6b80c" />


Mobile:
<img width="292" height="650" alt="image" src="https://github.com/user-attachments/assets/903c84f6-4364-466b-9616-72a5274bf545" />
<img width="294" height="613" alt="image" src="https://github.com/user-attachments/assets/49b56056-e975-471f-b734-f4dc5f0afb16" />


Note: Tab Header is not exactly the same with desktop, waiting QA for tabheader  

Figma Desktop Tabheader:
<img width="555" height="94" alt="image" src="https://github.com/user-attachments/assets/64a0495c-c45d-4a65-9f70-501c307fdfeb" />



Code implemented Tabheader Desktop:
<img width="555" height="94" alt="image" src="https://github.com/user-attachments/assets/4783f27f-59e3-4d71-8197-2b91907e81e3" />
