### PR TITLE
fixed the mobile view of navbar and navlinks gap

### DIFF
--- a/src/components/ui/navigation-bar.tsx
+++ b/src/components/ui/navigation-bar.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import Image from "next/image";
-import { FiChevronRight, FiChevronDown, FiMenu, FiX } from "react-icons/fi";
+import { FiChevronDown, FiMenu } from "react-icons/fi";
 
 // Data sources
 const headLinks = [
@@ -26,43 +26,46 @@ const infoPortal = [
 export default function Navbar() {
   return (
     <div className="sticky top-0 z-50 py-4 px-4 sm:px-6 lg:px-8 xl:px-24 2xl:px-40 select-none">
-      {/* Mobile: details/summary toggle (no hooks) */}
-      <details className="lg:hidden relative">
+      <details className="lg:hidden group relative">
         <summary className="list-none">
-          <div className="bg-mainblue h-14 flex items-center justify-between px-4 sm:px-6 rounded-none">
-            <Link href="/" className="relative h-6 w-20 sm:w-32">
+          <div className="flex items-center justify-start px-4 sm:px-6 group-open:bg-mainblue group-open:h-14">
+            <div className="text-mainblue group-open:text-white p-2 cursor-pointer">
+              <FiMenu size={22} className="block group-open:hidden" />
+              <FiMenu size={22} className="hidden group-open:block" />
+            </div>
+          </div>
+        </summary>
+
+        {/* Mobile menu panel overlay */}
+        <div className="absolute left-0 right-0 top-14 mt-0 px-6 bg-mainblue text-white rounded-b-4xl z-40 overflow-y-auto pb-6">
+          {/* Logo shown when menu is open */}
+          <div className="flex items-center justify-start pt-16 mb-4">
+            <Link href="/" className="relative h-8 w-24">
               <Image
                 src="/images/on-the-move-logo.png"
                 alt="On The Move Logo"
                 fill
               />
             </Link>
-            <div className="text-white p-2 cursor-pointer">
-              <FiMenu size={22} className="block group-open:hidden" />
-              <FiX size={22} className="hidden group-open:block" />
-            </div>
           </div>
-        </summary>
 
-        {/* Mobile menu panel overlay */}
-        <div className="absolute left-0 right-0 top-14 mt-0 px-0 bg-mainblue text-white rounded-b-2xl shadow-md divide-y divide-white/10 z-40  overflow-y-auto">
           {headLinks.map((l) => (
             <Link
               key={l.href}
               href={l.href}
-              className="block px-4 py-3 font-formular-mono hover:bg-white/10"
+              className="block px-4 py-3 font-formular-mono hover:bg-white/10 rounded-md"
             >
               {l.label}
             </Link>
           ))}
 
           {/* Offices collapsible */}
-          <details className="px-2 py-1 group/office">
-            <summary className="list-none w-full flex items-center justify-between px-2 py-2 font-formular-mono cursor-pointer hover:bg-white/10 rounded-md">
+          <details className="py-1 [&[open]_summary>svg]:rotate-180">
+            <summary className="w-full flex items-center justify-between px-4 py-3 font-formular-mono cursor-pointer hover:bg-white/10 rounded-md list-none">
               <span>Offices</span>
-              <FiChevronRight className="transition-transform duration-300 group-open/office:rotate-90" />
+              <FiChevronDown className="transition-transform duration-400" />
             </summary>
-            <div className="pl-4 pb-2">
+            <div className="pl-8 pb-2">
               {offices.map((o) => (
                 <Link
                   key={o.href}
@@ -77,18 +80,18 @@ export default function Navbar() {
 
           <Link
             href="/faq"
-            className="block px-4 py-3 font-formular-mono hover:bg-white/10"
+            className="block px-4 py-3 font-formular-mono hover:bg-white/10 rounded-md"
           >
             FAQ
           </Link>
 
           {/* Information portal collapsible */}
-          <details className="px-2 py-1 group/infop">
-            <summary className="list-none w-full flex items-center justify-between px-2 py-2 font-formular-mono cursor-pointer hover:bg-white/10 rounded-md">
+          <details className="py-1 [&[open]_summary>svg]:rotate-180">
+            <summary className="w-full flex items-center justify-between px-4 py-3 font-formular-mono cursor-pointer hover:bg-white/10 rounded-md list-none">
               <span>Information Portal</span>
-              <FiChevronRight className="transition-transform duration-300 group-open/infop:rotate-90" />
+              <FiChevronDown className="transition-transform duration-400" />
             </summary>
-            <div className="pl-4 pb-2">
+            <div className="pl-8 pb-2">
               {infoPortal.map((i) => (
                 <Link
                   key={i.href}
@@ -113,7 +116,7 @@ export default function Navbar() {
               fill
             />
           </Link>
-          <div className="flex items-center flex-nowrap  space-x-12 md:space-x-12 xl:space-x-16 2xl:space-x-24s">
+          <div className="flex items-center flex-nowrap space-x-20 lg:space-x-16 xl:space-x-24 2xl:space-x-20 3xl:space-x-32">
             {headLinks.map((l) => (
               <Link
                 key={l.href}
@@ -131,7 +134,7 @@ export default function Navbar() {
                 className="flex items-center gap-1 text-white cursor-pointer font-formular-mono whitespace-nowrap lg:text-sm xl:text-base"
               >
                 Offices
-                <FiChevronDown className="text-white transition-transform duration-200 group-hover:rotate-180 ml-2 xl:ml-4" />
+                <FiChevronDown className="text-white transition-transform duration-400 group-hover:rotate-180 ml-2 xl:ml-4" />
               </button>
               <div className="absolute left-1/2 top-full -translate-x-1/2 hidden group-hover:block z-10">
                 <div className="min-w-48 bg-white border mt-4 border-mainblue rounded-b-md shadow-lg py-1">
@@ -162,7 +165,7 @@ export default function Navbar() {
                 className="flex items-center gap-1 text-white cursor-pointer font-formular-mono whitespace-nowrap lg:text-sm xl:text-base"
               >
                 Information Portal
-                <FiChevronDown className="text-white transition-transform duration-200 group-hover:rotate-180 ml-2 xl:ml-4" />
+                <FiChevronDown className="text-white transition-transform duration-400 group-hover:rotate-180 ml-2 xl:ml-4" />
               </button>
               <div className="absolute left-1/2 top-full -translate-x-1/2 hidden group-hover:block z-10">
                 <div className="min-w-60 bg-white border mt-4 border-mainblue rounded-b-md shadow-lg py-1">


### PR DESCRIPTION
For issue #46, #58 & #66

fixed the mobile view and closed state and opened state on mobile:
![download](https://github.com/user-attachments/assets/17544951-df6f-47e0-8dbf-6479902af036)
![download](https://github.com/user-attachments/assets/4de98ff8-960f-495e-97ca-a4fe5b76be9c)


also the spacing between navlinks in larger breakpoints (1440 - 1520px):
![download](https://github.com/user-attachments/assets/7e3df287-f178-4cf7-8453-62ab8560d64e)
