### PR TITLE
fix: fix distorted logo image and not visible on certain screen sizes

### DIFF
--- a/src/components/ui/navigation-bar.tsx
+++ b/src/components/ui/navigation-bar.tsx
@@ -110,14 +110,14 @@ export default function Navbar() {
       {/* Desktop nav (unchanged layout; mapped content) */}
       <div className="hidden lg:block">
         <div className="bg-mainblue h-14 flex items-center justify-between lg:px-6 xl:px-10 rounded-full">
-          <Link href="/" className="relative h-6 w-20  xl:w-22">
+          <Link href="/" className="relative h-6 w-20 xl:w-22">
             <Image
               src="/images/on-the-move-logo.png"
               alt="On The Move Logo"
               fill
             />
           </Link>
-          <div className="flex items-center flex-nowrap space-x-20 lg:space-x-16 xl:space-x-24 2xl:space-x-20 3xl:space-x-32">
+          <div className="flex items-center flex-nowrap space-x-20 lg:space-x-16 2xl:space-x-20 3xl:space-x-32">
             {headLinks.map((l) => (
               <Link
                 key={l.href}


### PR DESCRIPTION
### Before
<img width="1173" height="148" alt="Screenshot 2025-11-27 211305" src="https://github.com/user-attachments/assets/10ee9373-ee21-4a17-afcd-07ee38e45a2d" />

### After
<img width="1171" height="153" alt="Screenshot 2025-11-27 211324" src="https://github.com/user-attachments/assets/d0552deb-980e-4626-805c-4a52cbfd32b9" />
