### PR TITLE
fix: removed the word SAMAHAN on Council of Class Presidents heading

### DIFF
--- a/src/components/sections/independent-bodies-section.tsx
+++ b/src/components/sections/independent-bodies-section.tsx
@@ -53,7 +53,7 @@ function IndependentBodiesSection() {
           imgSource: "/images/independent-bodies/ccp.png",
           imgAlt: "SAMAHAN Council of Class Presidents Logo",
         }}
-        organizationName="SAMAHAN Council of Class Presidents"
+        organizationName="Council of Class Presidents"
         facebookName="ADDU Council of Class Presidents"
         facebookLink={"https://www.facebook.com/adduccp"}
       />

--- a/src/components/ui/independent-bodies.tsx
+++ b/src/components/ui/independent-bodies.tsx
@@ -41,7 +41,7 @@ const IndependentBodies = ({
             </div>
           </CardHeader>
           <CardContent className="flex flex-col items-center p-0">
-            <h1 className="font-formular-black text-center text-xs text-mainblue md:text-base">
+            <h1 className="font-formular-black uppercase text-center text-xs text-mainblue md:text-base">
               {organizationName}
             </h1>
             <div className="mt-1 flex w-full max-w-40 items-start justify-center gap-1 text-blue1 md:max-w-50 xl:max-w-55">


### PR DESCRIPTION
Resolves issue #174

other: added uppercase class to organization name heading in Independent Bodies card to align with figma design
<img width="700" alt="image" src="https://github.com/user-attachments/assets/33dcb150-9055-4d06-9add-c82f570ca37d" />
