### PR TITLE
fix: increase hero image quality

### DIFF
--- a/src/components/ui/hero-banner.tsx
+++ b/src/components/ui/hero-banner.tsx
@@ -8,24 +8,34 @@ interface HeroBannerProps {
   header2?: string;
 }
 
-const HeroBanner: React.FC<HeroBannerProps> = ({ imageSrc, imageAlt, header1, header2 }) => (
+const HeroBanner: React.FC<HeroBannerProps> = ({
+  imageSrc,
+  imageAlt,
+  header1,
+  header2,
+}) => (
   <div className="relative w-full h-56 xs:h-64 md:h-72 lg:h-96 2xl:h-[600px] -mt-22 z-10">
     <Image
       src={imageSrc}
       alt={imageAlt}
       fill
+      quality={100}
       className="object-cover"
       priority
     />
     <div className="absolute inset-0 flex flex-col items-center justify-center z-10 gap-y-2">
       {header1 && (
         <div>
-          <span className="text-white font-formular-black text-lg xs:text-xl lg:text-4xl 2xl:text-6xl">{header1}</span>
+          <span className="text-white font-formular-black text-lg xs:text-xl lg:text-4xl 2xl:text-6xl">
+            {header1}
+          </span>
         </div>
       )}
       {header2 && (
         <div>
-          <span className="text-white font-trapix text-xl xs:text-2xl lg:text-5xl 2xl:text-7xl">{header2}</span>
+          <span className="text-white font-trapix text-xl xs:text-2xl lg:text-5xl 2xl:text-7xl">
+            {header2}
+          </span>
         </div>
       )}
     </div>


### PR DESCRIPTION
Resolves issue #149 

## Changes
- add quality attrbute and set it to 100 on Image tag in "/src/components/ui/hero-banner.tsx"


**Desktop View:**
<img width="1894" height="828" alt="image" src="https://github.com/user-attachments/assets/8d7c1efb-dd00-4dc6-aaf5-837ef1d2f6cd" />
<img width="1891" height="597" alt="image" src="https://github.com/user-attachments/assets/87881bdc-b502-493f-9aee-790b5f88c356" />
<img width="1892" height="773" alt="image" src="https://github.com/user-attachments/assets/6ad89c6d-f09e-41ea-9c57-7278cc0d8583" />

etc...