### PR TITLE
fix: adjust wrapping on footer address line

### DIFF
--- a/src/components/ui/Footer.tsx
+++ b/src/components/ui/Footer.tsx
@@ -116,8 +116,9 @@ export default function Footer() {
             <div className="font-trapix text-lg mb-2 lg:px-4">Address</div>
             <ul className="list-none space-y-2 font-formular-mono text-xs lg:px-4 mt-4 max-w-xs">
               <li>
-                Mezzanine Level, Martin Building, Ateneo de Davao University
-                E.Jacinto Street, Davao City 8000
+                Mezzanine Level, Martin Building, Ateneo de Davao University E.{" "}
+                <br />
+                Jacinto Street, Davao City 8000
               </li>
             </ul>
           </div>


### PR DESCRIPTION
Resolves issue #69 

## Changes
- Fixed the alignment on the footer address line

**Desktop View:**
<img width="1897" height="646" alt="image" src="https://github.com/user-attachments/assets/3af8fda0-983a-43fe-85ab-e184ac3b9de6" />
