### PR TITLE
style: increase "other samahan offices" font size

### DIFF
--- a/src/components/sections/other-offices.tsx
+++ b/src/components/sections/other-offices.tsx
@@ -1,5 +1,6 @@
 import { otherSamahanOfficesData } from "@/data/other-samahan-offices-data";
 import OfficeCard from "../ui/OfficeCard";
+
 interface OtherOfficesProps {
   office: "osp" | "osvp" | "osg" | "ost";
 }
@@ -9,6 +10,7 @@ export default function OtherOffices({ office }: OtherOfficesProps) {
   );
   return (
     <div className="px-6 md:px-8 lg:px-12">
+      {/* Increased Size */}
       <h1 className="font-formular-black text-center text-3xl text-mainblue md:text-5xl">
         OTHER SAMAHAN OFFICES
       </h1>


### PR DESCRIPTION
Resolves issue #162 

## Changes
- Increased font size for other-offices component header in "/src/components/sections/other-offices.tsx"

**Desktop View:**
<img width="1892" height="688" alt="image" src="https://github.com/user-attachments/assets/0357b02e-f2a3-4d80-ade5-68a4c0409229" />


**Mobile View:**
<img width="315" height="832" alt="image" src="https://github.com/user-attachments/assets/88e46da9-8868-4dc0-ad23-2512dc62926a" />
