### PR TITLE
fix: correct punctuation rendering in Samahan on Track section

### DIFF
--- a/src/components/sections/samahan-on-track.tsx
+++ b/src/components/sections/samahan-on-track.tsx
@@ -118,7 +118,7 @@ export default function OnTrack() {
     "use club email",
     "submit after every email", // Note: Transcribed from image, though contextually might mean "event"
     <>
-    <span>always CC {LPAREN}carbon copy{RPAREN} COA-D's email</span>
+    <span>always CC {LPAREN}carbon copy{RPAREN} COA-D{APOSTROPHE}s email</span>
     </>
   ];
 


### PR DESCRIPTION
resolves issue #253

The Formular font is missing glyphs for special punctuation characters (parentheses, colons, brackets, quotes, slashes, dashes, apostrophes, etc.), which prevents them from rendering on the page.

- added arial fallbacks for special characters
- wrapped content that requires special punctuation in spans to prevent layout breaks in responsive view
- wrapped descriptions that require fallback in React fragment <></>

### IMAGES
<img width="383" alt="image" src="https://github.com/user-attachments/assets/58b8af93-78e4-4600-92de-1da3be816e5f" />
<img width="241" alt="image" src="https://github.com/user-attachments/assets/1f0867ce-fba7-4d7d-8187-4eb4b557aa07" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/90f70b58-74e0-49d3-a0b6-caa3aa8ada2e" />
<img width="900" alt="image" src="https://github.com/user-attachments/assets/3ad03efe-1760-4205-ae12-26ed4187a187" />