### PR TITLE
fix: Added horizontal padding to document entry component

### DIFF
--- a/src/components/ui/document-entry.tsx
+++ b/src/components/ui/document-entry.tsx
@@ -46,7 +46,7 @@ export default function DocumentEntry({ documentName, description, office, actNu
     }
 
     return (
-        <Link href={href} className="group flex flex-col py-5 lg:py-12 lg:px-5 w-full mx-auto hover:bg-mainblue transition-colors duration-200  border-b-2 border-mainblue hover:border-mainblue">
+        <Link href={href} className="group flex flex-col py-5 lg:py-12 md:px-5 w-full mx-auto hover:bg-mainblue transition-colors duration-200  border-b-2 border-mainblue hover:border-mainblue">
             {/* Document Name */}
             <div className="document-name font-formular-black text-lg text-mainblue font-black group-hover:text-white">
                 {withFontFallback(documentName)}


### PR DESCRIPTION
- Added a slight horizontal padding (px-4 on larger viewports) to the document entry component so that it does not look awkward on hover.

**BEFORE:**
<img width="1723" height="453" alt="Screenshot 2025-12-19 165034" src="https://github.com/user-attachments/assets/aa66e25a-a117-4359-b6a3-4ec90126c954" />


**AFTER:**
<img width="1613" height="376" alt="image" src="https://github.com/user-attachments/assets/e8e31b44-67aa-4580-8141-414cdbc63d7c" />
