### PR TITLE
fix: Fixed dynamic link error for request buttons

### DIFF
--- a/src/components/sections/request-document-tab-section.tsx
+++ b/src/components/sections/request-document-tab-section.tsx
@@ -126,7 +126,7 @@ export default function DocumentRequestTabSection() {
         </div>
         <Button 
           className="cursor-pointer py-3 px-6 rounded-2xl mt-6 sm:mt-6 md:mt-8"
-          onClick={() => window.open("https://forms.gle/icompp-booking-form", "_blank")}
+          onClick={() => window.open("https://www.addu.edu.ph/registrar/", "_blank")}
         >
           REQUEST REGISTRAR CERTIFICATE
         </Button>
@@ -145,7 +145,7 @@ export default function DocumentRequestTabSection() {
         </div>
         <Button 
           className="cursor-pointer py-3 px-6 rounded-2xl mt-6 sm:mt-6 md:mt-8"
-          onClick={() => window.open("https://forms.gle/icompp-booking-form", "_blank")}
+          onClick={() => window.open("https://www.addu.edu.ph/registrar/", "_blank")}
         >
           REQUEST CERTIFICATE
         </Button>


### PR DESCRIPTION
- Clicking on the "Request Registrar Certificate" and "Request Certificate" buttons now lead to AdDU's registrar page.

**Clicking on these buttons:**
<img width="1442" height="423" alt="image" src="https://github.com/user-attachments/assets/49d65c1d-e245-4aac-b6df-cab9d375eda3" />

**Will now route to the correct page:**
<img width="1914" height="790" alt="image" src="https://github.com/user-attachments/assets/90420949-7ed7-4e27-9233-9267045e3a05" />
