### PR TITLE
fix: remove placeholder desc in osvp page

### DIFF
--- a/src/components/pages/osvp-page.tsx
+++ b/src/components/pages/osvp-page.tsx
@@ -65,7 +65,6 @@ function OSVPPage() {
 
       <ProfileGroup
         groupTitle="OFFICE OF THE LEGISLATIVE SECRETARY"
-        description="Lorem ipsum dolor sit amet, cons ectetuer adipiscing elit, sed diam ibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat."
       >
         <div className="grid grid-cols-2 lg:grid-cols-6 gap-x-4 gap-y-12 lg:gap-x-10 justify-items-center">
           <div className="col-span-1 lg:col-start-1 lg:col-span-2">


### PR DESCRIPTION
remove the placeholder description text for the office of Legislative Secretary on the OSVP page

### BEFORE
<img width="800" alt="image" src="https://github.com/user-attachments/assets/e552b0d1-d927-4a58-8629-4bb2aa877415" />

### AFTER
<img width="800" alt="image" src="https://github.com/user-attachments/assets/ff727ea4-8567-49f2-9dd5-bf4749c79bea" />
